### PR TITLE
fix npm path error in install script

### DIFF
--- a/scripts/install_dependencies.sh
+++ b/scripts/install_dependencies.sh
@@ -16,7 +16,7 @@ nvm use 22
 
 
 # Install global tools and dependencies
-sudo npm install -g pnpm@8 pm2
-sudo rm -f pnpm-lock.yaml
+npm install -g pnpm@8 pm2
+rm -f pnpm-lock.yaml
 pnpm install
 


### PR DESCRIPTION
## Summary
- handle missing sudo while keeping Node path for global installs
- remove sudo from Node installs because CodeDeploy runs as `ec2-user`

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688514438480833089e4c6aaabbcaa0a