### PR TITLE
Ensure build step before pm2 start

### DIFF
--- a/scripts/start_server.sh
+++ b/scripts/start_server.sh
@@ -5,4 +5,6 @@ cd /home/ec2-user/app
 . "$HOME/.nvm/nvm.sh"
 nvm use 22
 
+pnpm build
+
 pm2 restart app || pm2 start pnpm --name "app" -- start


### PR DESCRIPTION
## Summary
- run `pnpm build` in `start_server.sh` so a production build is available before starting via pm2

## Testing
- `pnpm install`
- `pnpm lint`
- `pnpm build` *(fails: Page "/programs/[slug]" is missing "generateStaticParams()" so it cannot be used with "output: export" config.)*


------
https://chatgpt.com/codex/tasks/task_e_68859fe305108330a7bb60c4f4d5f2d9