### PR TITLE
Fix Next.js build for EC2 deploy

### DIFF
--- a/.github/workflows/ec2-deploy.yml
+++ b/.github/workflows/ec2-deploy.yml
@@ -67,7 +67,7 @@ jobs:
           host: ${{ secrets.EC2_HOST }}
           username: ${{ secrets.EC2_USERNAME }}
           key: ${{ secrets.EC2_KEY }}
-          source: ".next,public,package.json,pnpm-lock.yaml"
+          source: "build,public,package.json,pnpm-lock.yaml"
           target: "~/app"
 
       - name: SSH and Run

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,6 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig & { webpack?: Function } = {
-  output: 'export',
   trailingSlash: true,
   distDir: 'build',
   images: {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -37,6 +37,7 @@
     "build/types/**/*.ts"
   ],
   "exclude": [
-    "node_modules"
+    "node_modules",
+    "build"
   ]
 }


### PR DESCRIPTION
## Summary
- remove `output: 'export'` to enable server build
- skip building on the EC2 instance
- exclude build directory from TypeScript checking

## Testing
- `pnpm lint`
- `pnpm build`


------
https://chatgpt.com/codex/tasks/task_e_68859fe305108330a7bb60c4f4d5f2d9