### PR TITLE
Use instance IAM role by default

### DIFF
--- a/src/lib/dynamodb.ts
+++ b/src/lib/dynamodb.ts
@@ -8,10 +8,6 @@ export function getDocClient() {
   if (!ddbDocClient) {
     const client = new DynamoDBClient({
       region: process.env.AWS_REGION,
-      credentials: {
-        accessKeyId: process.env.AWS_ACCESS_KEY_ID!,
-        secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY!,
-      },
     });
 
     ddbDocClient = DynamoDBDocumentClient.from(client);


### PR DESCRIPTION
## Summary
- rely on default credential chain when instantiating DynamoDB client

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6888ed0f3cec83309e1fcca8ae2d7771