### PR TITLE
Make API pages fully dynamic

### DIFF
--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -3,7 +3,7 @@ import NavigationButton from '@/components/navigation-button';
 import Program from '@/components/program';
 import { getAllPrograms, getProgram } from '@/lib/data/programs';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 interface ProgramPageProps {
   params: Promise<{

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -5,7 +5,7 @@ import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
 import Button from '@/components/btn';
 import Boids from '@/components/boids';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 export default async function ProgramsPage() {
     const programs = await getAllPrograms()

--- a/src/app/thoughts/[slug]/page.tsx
+++ b/src/app/thoughts/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Thought from '@/components/thought';
 import { getAllThoughts, getThought } from '@/lib/data/thoughts';
 import NavigationButton from '@/components/navigation-button';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 interface ThoughtPageProps {
   params: Promise<{

--- a/src/app/thoughts/page.tsx
+++ b/src/app/thoughts/page.tsx
@@ -5,7 +5,7 @@ import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
 import Button from '@/components/btn';
 import Boids from '@/components/boids';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 export default async function ThoughtsPage() {
 

--- a/src/app/writings/[slug]/page.tsx
+++ b/src/app/writings/[slug]/page.tsx
@@ -3,7 +3,7 @@ import Writing from '@/components/writing';
 import NavigationButton from '@/components/navigation-button';
 import { getAllWritings, getWriting } from '@/lib/data/writings';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 interface WritingPageProps {
   params: Promise<{

--- a/src/app/writings/page.tsx
+++ b/src/app/writings/page.tsx
@@ -5,7 +5,7 @@ import Button from '@/components/btn';
 import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
 import Boids from '@/components/boids';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 export default async function WritingsPage() {
   const writings = await getAllWritings();


### PR DESCRIPTION
## Summary
- use dynamic rendering on writings, thoughts, and programs pages

## Testing
- `npm run lint`
- `npm run build` *(fails: Region is missing during build)*

------
https://chatgpt.com/codex/tasks/task_e_68899568654c8330a270739db9df8cd1