### PR TITLE
Remove generateStaticParams from dynamic pages

### DIFF
--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import NavigationButton from '@/components/navigation-button';
 import Program from '@/components/program';
-import { getAllPrograms, getProgram } from '@/lib/data/programs';
+import { getProgram } from '@/lib/data/programs';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,15 +11,7 @@ interface ProgramPageProps {
   }>
 }
 
-export async function generateStaticParams() {
-  const programs = await getAllPrograms();
-  
-  return programs.map((program) => ({
-    slug: program.slug,
-  }))
-}
-
-export default async function ProgramPage({ params }: ProgramPageProps) { 
+export default async function ProgramPage({ params }: ProgramPageProps) {
   const awaitedParams = await params;
   const programData = await getProgram(awaitedParams.slug);
 

--- a/src/app/thoughts/[slug]/page.tsx
+++ b/src/app/thoughts/[slug]/page.tsx
@@ -1,6 +1,6 @@
 import { notFound } from 'next/navigation';
 import Thought from '@/components/thought';
-import { getAllThoughts, getThought } from '@/lib/data/thoughts';
+import { getThought } from '@/lib/data/thoughts';
 import NavigationButton from '@/components/navigation-button';
 
 export const dynamic = 'force-dynamic';
@@ -12,15 +12,7 @@ interface ThoughtPageProps {
 }
 
 
-export async function generateStaticParams() {
-  const thoughts = await getAllThoughts();
-  
-  return thoughts.map((thought) => ({
-    slug: thought.slug,
-  }));
-}
-
-export default async function ThoughtPage({ params }: ThoughtPageProps) { 
+export default async function ThoughtPage({ params }: ThoughtPageProps) {
   const awaitedParams = await params;
   const thoughtData = await getThought(awaitedParams.slug);
   

--- a/src/app/writings/[slug]/page.tsx
+++ b/src/app/writings/[slug]/page.tsx
@@ -1,7 +1,7 @@
 import { notFound } from 'next/navigation';
 import Writing from '@/components/writing';
 import NavigationButton from '@/components/navigation-button';
-import { getAllWritings, getWriting } from '@/lib/data/writings';
+import { getWriting } from '@/lib/data/writings';
 
 export const dynamic = 'force-dynamic';
 
@@ -11,15 +11,7 @@ interface WritingPageProps {
   }>
 }
 
-export async function generateStaticParams() {
-  const writings = await getAllWritings();
-  
-  return writings.map((writing) => ({
-    slug: writing.slug,
-  }));
-}
-
-export default async function WritingPage({ params }: WritingPageProps) { 
+export default async function WritingPage({ params }: WritingPageProps) {
   const awaitedParams = await params;
   const writingData = await getWriting(awaitedParams.slug);
   


### PR DESCRIPTION
## Summary
- simplify dynamic pages by dropping unused `generateStaticParams` functions
- keep `dynamic = 'force-dynamic'` export and the page components

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6889a55de4c0833082f5b0acfe33f3ae