### PR TITLE
Add admin login with content creation

### DIFF
--- a/src/app/api/admin/programs/route.ts
+++ b/src/app/api/admin/programs/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { PutCommand } from '@aws-sdk/lib-dynamodb';
+import { getDocClient } from '@/lib/dynamodb';
+
+export async function POST(req: Request) {
+  const cookieStore = await cookies();
+  if (cookieStore.get('adminAuth')?.value !== 'true') {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const data = await req.json();
+  const client = getDocClient();
+  const command = new PutCommand({
+    TableName: process.env.DYNAMODB_DATA_TABLE_NAME,
+    Item: {
+      '{contentType}#{slug}': `program#${data.slug}`,
+      metadata: 'metadata',
+      slug: data.slug,
+      content: data.content,
+      videoName: data.videoName,
+      githubUrl: data.githubUrl,
+    },
+  });
+  await client.send(command);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/thoughts/route.ts
+++ b/src/app/api/admin/thoughts/route.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { PutCommand } from '@aws-sdk/lib-dynamodb';
+import { getDocClient } from '@/lib/dynamodb';
+
+export async function POST(req: Request) {
+  const cookieStore = await cookies();
+  if (cookieStore.get('adminAuth')?.value !== 'true') {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const data = await req.json();
+  const client = getDocClient();
+  const command = new PutCommand({
+    TableName: process.env.DYNAMODB_DATA_TABLE_NAME,
+    Item: {
+      '{contentType}#{slug}': `thought#${data.slug}`,
+      metadata: 'metadata',
+      slug: data.slug,
+      content: data.content,
+      date: data.date || new Date().toISOString().split('T')[0],
+    },
+  });
+  await client.send(command);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/admin/writings/route.ts
+++ b/src/app/api/admin/writings/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+import { PutCommand } from '@aws-sdk/lib-dynamodb';
+import { getDocClient } from '@/lib/dynamodb';
+
+export async function POST(req: Request) {
+  const cookieStore = await cookies();
+  if (cookieStore.get('adminAuth')?.value !== 'true') {
+    return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
+  }
+  const data = await req.json();
+  const client = getDocClient();
+  const command = new PutCommand({
+    TableName: process.env.DYNAMODB_DATA_TABLE_NAME,
+    Item: {
+      '{contentType}#{slug}': `writing#${data.slug}`,
+      metadata: 'metadata',
+      slug: data.slug,
+      title: data.title,
+      content: data.content,
+      date: data.date || new Date().toISOString().split('T')[0],
+    },
+  });
+  await client.send(command);
+  return NextResponse.json({ success: true });
+}

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,0 +1,11 @@
+import { NextResponse } from 'next/server';
+
+export async function POST(req: Request) {
+  const { password } = await req.json();
+  if (password === process.env.ADMIN_PASSWORD) {
+    const res = NextResponse.json({ success: true });
+    res.cookies.set('adminAuth', 'true', { httpOnly: true, path: '/' });
+    return res;
+  }
+  return NextResponse.json({ success: false }, { status: 401 });
+}

--- a/src/app/api/logout/route.ts
+++ b/src/app/api/logout/route.ts
@@ -1,0 +1,7 @@
+import { NextResponse } from 'next/server';
+
+export async function POST() {
+  const res = NextResponse.json({ success: true });
+  res.cookies.set('adminAuth', '', { httpOnly: true, path: '/', maxAge: 0 });
+  return res;
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -7,6 +7,9 @@ import { ThemeProvider } from "@/components/theme-provider";
 import ThemeToggle from "@/components/theme-toggle";
 import Copyright from "@/components/copyright";
 import NavigationTracker from "@/components/navigation-tracker";
+import { isAdmin } from "@/lib/auth";
+import Link from "next/link";
+import Button from "@/components/btn";
 
 export const viewport: Viewport = {
   themeColor: "#000000",
@@ -26,11 +29,13 @@ export const metadata: Metadata = {
 
 const deptnf = localFont({ src: "../../public/DepartureMonoNerdFontMono-Regular.otf" });
 
-export default function RootLayout({
+export default async function RootLayout({
   children,
 }: Readonly<{
   children: React.ReactNode;
 }>) {
+
+  const admin = await isAdmin();
 
   return (
     <html lang="en" suppressHydrationWarning={true}>
@@ -43,6 +48,17 @@ export default function RootLayout({
         <ThemeProvider>
           <NavigationTracker />
           <ThemeToggle />
+          <div className="fixed top-4 left-4 z-50">
+            {admin ? (
+              <form action="/api/logout" method="post">
+                <Button text="logout" variant="outline" size="small" />
+              </form>
+            ) : (
+              <Link href="/login">
+                <Button text="login" variant="outline" size="small" />
+              </Link>
+            )}
+          </div>
           <main className="flex min-h-screen flex-col">
             <div className="flex-grow pb-16">
               {children}

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -1,0 +1,41 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Button from '@/components/btn';
+
+export default function LoginPage() {
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setError('');
+    const res = await fetch('/api/login', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ password })
+    });
+    if (res.ok) {
+      router.push('/');
+    } else {
+      setError('invalid password');
+    }
+  };
+
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen gap-4">
+      <form onSubmit={handleSubmit} className="flex flex-col gap-2">
+        <input
+          type="password"
+          className="border rounded p-2 text-black"
+          placeholder="Admin password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+        />
+        <Button text="login" variant="outline" />
+        {error && <p className="text-red-500">{error}</p>}
+      </form>
+    </div>
+  );
+}

--- a/src/app/programs/new/Form.tsx
+++ b/src/app/programs/new/Form.tsx
@@ -1,0 +1,32 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Button from '@/components/btn';
+
+export default function NewProgramForm() {
+  const [slug, setSlug] = useState('');
+  const [content, setContent] = useState('');
+  const [videoName, setVideoName] = useState('');
+  const [githubUrl, setGithubUrl] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/admin/programs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug, content, videoName, githubUrl }),
+    });
+    router.push('/programs');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 p-4">
+      <input value={slug} onChange={e => setSlug(e.target.value)} placeholder="slug" className="border p-2 text-black" />
+      <input value={videoName} onChange={e => setVideoName(e.target.value)} placeholder="video name" className="border p-2 text-black" />
+      <input value={githubUrl} onChange={e => setGithubUrl(e.target.value)} placeholder="github url" className="border p-2 text-black" />
+      <textarea value={content} onChange={e => setContent(e.target.value)} placeholder="content" className="border p-2 text-black" rows={10} />
+      <Button text="save" variant="outline" />
+    </form>
+  );
+}

--- a/src/app/programs/new/page.tsx
+++ b/src/app/programs/new/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { isAdmin } from '@/lib/auth';
+import NewProgramForm from './Form';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NewProgramPage() {
+  const admin = await isAdmin();
+  if (!admin) {
+    redirect('/login');
+  }
+  return <NewProgramForm />;
+}

--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -4,11 +4,13 @@ import { getAllPrograms } from '@/lib/data/programs';
 import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
 import Button from '@/components/btn';
 import Boids from '@/components/boids';
+import { isAdmin } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
 export default async function ProgramsPage() {
     const programs = await getAllPrograms()
+    const admin = await isAdmin();
 
     return (
     <div className="min-h-screen relative">
@@ -23,7 +25,14 @@ export default async function ProgramsPage() {
           </Link>
         ))}
       </div>
+      {admin && (
+        <div className="mt-4">
+          <Link href="/programs/new">
+            <Button text="add program" variant="outline" />
+          </Link>
+        </div>
+      )}
       <NavigationButton />
     </div>
-    )    
+    )
 }

--- a/src/app/thoughts/new/Form.tsx
+++ b/src/app/thoughts/new/Form.tsx
@@ -1,0 +1,28 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Button from '@/components/btn';
+
+export default function NewThoughtForm() {
+  const [slug, setSlug] = useState('');
+  const [content, setContent] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/admin/thoughts', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug, content }),
+    });
+    router.push('/thoughts');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 p-4">
+      <input value={slug} onChange={e => setSlug(e.target.value)} placeholder="slug" className="border p-2 text-black" />
+      <textarea value={content} onChange={e => setContent(e.target.value)} placeholder="content" className="border p-2 text-black" rows={10} />
+      <Button text="save" variant="outline" />
+    </form>
+  );
+}

--- a/src/app/thoughts/new/page.tsx
+++ b/src/app/thoughts/new/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { isAdmin } from '@/lib/auth';
+import NewThoughtForm from './Form';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NewThoughtPage() {
+  const admin = await isAdmin();
+  if (!admin) {
+    redirect('/login');
+  }
+  return <NewThoughtForm />;
+}

--- a/src/app/thoughts/page.tsx
+++ b/src/app/thoughts/page.tsx
@@ -4,12 +4,14 @@ import { getAllThoughts } from '@/lib/data/thoughts';
 import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
 import Button from '@/components/btn';
 import Boids from '@/components/boids';
+import { isAdmin } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
 export default async function ThoughtsPage() {
 
     const thoughts = await getAllThoughts()
+    const admin = await isAdmin();
     
     // Sort thoughts by date (newest first)
     const sortedThoughts = thoughts.sort((a, b) => {
@@ -64,7 +66,14 @@ export default async function ThoughtsPage() {
           </div>
         )}
       </div>
+      {admin && (
+        <div className="mt-4">
+          <Link href="/thoughts/new">
+            <Button text="add thought" variant="outline" />
+          </Link>
+        </div>
+      )}
       <NavigationButton />
     </div>
-    )    
+    )
 }

--- a/src/app/writings/new/Form.tsx
+++ b/src/app/writings/new/Form.tsx
@@ -1,0 +1,30 @@
+'use client';
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import Button from '@/components/btn';
+
+export default function NewWritingForm() {
+  const [slug, setSlug] = useState('');
+  const [title, setTitle] = useState('');
+  const [content, setContent] = useState('');
+  const router = useRouter();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await fetch('/api/admin/writings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ slug, title, content }),
+    });
+    router.push('/writings');
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="flex flex-col gap-2 p-4">
+      <input value={slug} onChange={e => setSlug(e.target.value)} placeholder="slug" className="border p-2 text-black" />
+      <input value={title} onChange={e => setTitle(e.target.value)} placeholder="title" className="border p-2 text-black" />
+      <textarea value={content} onChange={e => setContent(e.target.value)} placeholder="content" className="border p-2 text-black" rows={10} />
+      <Button text="save" variant="outline" />
+    </form>
+  );
+}

--- a/src/app/writings/new/page.tsx
+++ b/src/app/writings/new/page.tsx
@@ -1,0 +1,13 @@
+import { redirect } from 'next/navigation';
+import { isAdmin } from '@/lib/auth';
+import NewWritingForm from './Form';
+
+export const dynamic = 'force-dynamic';
+
+export default async function NewWritingPage() {
+  const admin = await isAdmin();
+  if (!admin) {
+    redirect('/login');
+  }
+  return <NewWritingForm />;
+}

--- a/src/app/writings/page.tsx
+++ b/src/app/writings/page.tsx
@@ -4,11 +4,13 @@ import { getAllWritings } from '@/lib/data/writings';
 import Button from '@/components/btn';
 import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
 import Boids from '@/components/boids';
+import { isAdmin } from '@/lib/auth';
 
 export const dynamic = 'force-dynamic';
 
 export default async function WritingsPage() {
   const writings = await getAllWritings();
+  const admin = await isAdmin();
   
   // Get current date and first day of current month
   const now = new Date();
@@ -58,9 +60,9 @@ export default async function WritingsPage() {
           <div className="flex flex-col items-center gap-4">
             <h2 className="text-xl font-semibold mb-2">previous</h2>
             {previousWritings.map((writing) => (
-              <Link 
+              <Link
                 key={writing.slug}
-                href={`/writings/${writing.slug}`} 
+                href={`/writings/${writing.slug}`}
                 className="hover:opacity-70 transition-opacity"
               >
                 <Button text={writing.title} variant="outline" size="medium" icon={<ArrowRightIcon className="h-3 w-3" />} iconPosition="right" />
@@ -69,6 +71,13 @@ export default async function WritingsPage() {
           </div>
         )}
       </div>
+      {admin && (
+        <div className="mt-4">
+          <Link href="/writings/new">
+            <Button text="add writing" variant="outline" />
+          </Link>
+        </div>
+      )}
       <NavigationButton />
     </div>
   )

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,0 +1,7 @@
+import { cookies } from 'next/headers';
+
+export async function isAdmin() {
+  const cookieStore = await cookies();
+  const value = cookieStore.get('adminAuth')?.value;
+  return value === 'true';
+}


### PR DESCRIPTION
## Summary
- implement admin login/logout using cookie
- add helper to check admin
- show login or logout option in layout
- add forms and API routes to create writings, thoughts, and programs
- display "add" buttons on list pages for admins

## Testing
- `npm install`
- `npx tsc --noEmit`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6889b7734d6c83309b058f3705134bf0