### PR TITLE
Improve mobile layout

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -21,14 +21,20 @@ canvas {
 
 html {
   background: var(--background);
-  overflow: hidden;
   height: 100%;
+  overflow-x: hidden;
 }
 
 body {
   color: var(--foreground);
   background: var(--background);
   transition: background-color 0.3s ease, color 0.3s ease;
-  overflow: hidden;
-  height: 100%;
+  min-height: 100%;
+  overflow-x: hidden;
+}
+
+@media (max-width: 640px) {
+  body {
+    padding: 1rem;
+  }
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,9 +11,11 @@ export default async function Home() {
 
   return (
     <>
-      <Boids />
-      <LangtonLoops />
-      <div className="fixed top-4 right-4 z-50 flex flex-col items-center gap-2">
+      <div className="hidden sm:block">
+        <Boids />
+        <LangtonLoops />
+      </div>
+      <div className="sm:fixed sm:top-4 sm:right-4 z-50 flex flex-col items-center gap-2 mt-4 sm:mt-0">
         <Image
           src="/images/pixelated-sami.png"
           alt="Sami"
@@ -28,25 +30,18 @@ export default async function Home() {
         )}
       </div>
       <div className="flex flex-col items-center min-h-screen pb-16 md:pb-20">
-        <div className="w-full max-w-3xl mt-12 self-start px-4 z-10">
-        <div>
-          <h1 className="text-3xl font-semibold text-gray-400">hello.</h1>
-          <h2 className="mt-2 text-2xl" style={{ color: 'rgba(180, 90, 70, 0.9)' }}>
-          software engineer @ AWS | RPI CS &apos;23
-          
-          </h2> 
-          
-          <p className="mt-2 text-gray-400">
-          self-organizing systems, self-replication, and mechanistic interpretability.
-          </p>
-          <p className="mt-2 text-gray-400">
-          
+        <div className="w-full max-w-3xl mt-16 sm:mt-20 px-4 z-10 text-center sm:text-left">
+          <h1 className="text-4xl sm:text-5xl font-semibold text-gray-400">hello.</h1>
+          <h2 className="mt-2 text-xl sm:text-2xl" style={{ color: 'rgba(180, 90, 70, 0.9)' }}>
+            software engineer @ AWS | RPI CS &apos;23
+          </h2>
+          <p className="mt-4 text-gray-400">
+            self-organizing systems, self-replication, and mechanistic interpretability.
           </p>
         </div>
-      </div>
 
       {/* Buttons row */}
-      <div className="flex flex-row gap-4 md:gap-6 mt-auto">
+      <div className="flex flex-col sm:flex-row w-full gap-4 md:gap-6 mt-auto px-4">
         <Link href="/writings" className="text-white hover:text-gray-300 z-10">
           <Button
             text={


### PR DESCRIPTION
## Summary
- hide canvas effects on small screens
- reposition avatar and center hero text
- increase body padding on phones

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ac714a65c8330aef328fadafa6efa