### PR TITLE
Adjust default theme and center home buttons

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { isAdmin } from "@/lib/auth";
 import Button from "@/components/btn";
 
 export const viewport: Viewport = {
-  themeColor: "#000000",
+  themeColor: "#f4f1ed",
   width: "device-width",
   initialScale: 1,
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -41,7 +41,7 @@ export default async function Home() {
         </div>
 
       {/* Buttons row */}
-      <div className="flex flex-col sm:flex-row w-full gap-4 md:gap-6 mt-auto px-4">
+      <div className="flex flex-col sm:flex-row w-full gap-4 md:gap-6 mt-auto px-4 sm:justify-center">
         <Link href="/writings" className="text-white hover:text-gray-300 z-10">
           <Button
             text={

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -12,14 +12,14 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('dark');
+  const [theme, setTheme] = useState<Theme>('light');
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
-    // Check for saved theme preference or default to 'dark'
+    // Check for saved theme preference or default to 'light'
     const savedTheme = localStorage.getItem('theme') as Theme | null;
-    const initialTheme = savedTheme || 'dark';
+    const initialTheme = savedTheme || 'light';
     setTheme(initialTheme);
     
     // Apply theme class to document


### PR DESCRIPTION
## Summary
- default to light theme on first load
- tweak meta theme color
- center home page buttons for larger screens

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688ad22f10a08330ab88879d7e8e24be