### PR TITLE
Add hero scroll nav and update dark theme

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,4 +11,11 @@ pnpm dev
 bun dev
 ```
 
+## Environment Variables
+
+Set `AWS_REGION` and either `ADMIN_PASSWORD_SECRET_NAME` or
+`ADMIN_PASSWORD_SECRET_KEY` to the name of the AWS Secrets Manager secret
+containing your admin credentials. The secret JSON must include an
+`ADMIN_PASSWORD` field.
+
 

--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import Button from '@/components/btn';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+
+export default function HomeClient({ admin }: { admin: boolean }) {
+  const [showNav, setShowNav] = useState(false);
+
+  useEffect(() => {
+    const onScroll = () => {
+      setShowNav(window.scrollY > window.innerHeight * 0.1);
+    };
+    window.addEventListener('scroll', onScroll);
+    return () => window.removeEventListener('scroll', onScroll);
+  }, []);
+
+  const Buttons = () => (
+    <>
+      <Link href="/writings">
+        <Button
+          text="writings"
+          variant="outline"
+          size="medium"
+          icon={<ArrowRightIcon className="h-3 w-3" />}
+          iconPosition="right"
+        />
+      </Link>
+      <Link href="/thoughts">
+        <Button
+          text="thoughts"
+          variant="outline"
+          size="medium"
+          icon={<ArrowRightIcon className="h-3 w-3" />}
+          iconPosition="right"
+        />
+      </Link>
+      <Link href="/programs">
+        <Button
+          text="programs"
+          variant="outline"
+          size="medium"
+          icon={<ArrowRightIcon className="h-3 w-3" />}
+          iconPosition="right"
+        />
+      </Link>
+      <Link href="/playground">
+        <Button
+          text="playground"
+          variant="outline"
+          size="medium"
+          icon={<ArrowRightIcon className="h-3 w-3" />}
+          iconPosition="right"
+        />
+      </Link>
+    </>
+  );
+
+  return (
+    <>
+      <nav
+        className={`fixed top-0 w-full bg-background/80 backdrop-blur-sm flex justify-center gap-4 py-2 z-40 transition-opacity ${showNav ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+      >
+        <Buttons />
+      </nav>
+      <section className="flex flex-col items-center justify-end min-h-screen pb-16 md:pb-20">
+        <div className="flex justify-center gap-4">
+          <Buttons />
+        </div>
+      </section>
+      <section className="max-w-3xl mx-auto mt-20 space-y-6 bg-background/60 backdrop-blur-md p-6 text-gray-300">
+        <div className="text-center sm:text-left">
+          <h1 className="text-4xl sm:text-5xl font-semibold text-gray-400">hello.</h1>
+          <h2 className="mt-2 text-xl sm:text-2xl" style={{ color: 'rgba(180, 90, 70, 0.9)' }}>
+            software engineer @ AWS | RPI CS &apos;23
+          </h2>
+          <p className="mt-4 text-gray-400">
+            self-organizing systems, self-replication, and mechanistic interpretability.
+          </p>
+        </div>
+        <p>
+          welcome to my corner of the internet. more content will gradually fill this page as i figure out what belongs here.
+        </p>
+        <p>
+          in the meantime, explore the links above or check back soon for new thoughts and programs.
+        </p>
+        {!admin && (
+          <div className="mt-4 flex justify-center">
+            <Link href="/login">
+              <Button text="login" variant="outline" size="small" />
+            </Link>
+          </div>
+        )}
+      </section>
+    </>
+  );
+}

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -9,8 +9,8 @@ canvas {
 
 :root {
   /* Default dark theme */
-  --background: #0a0a0a;
-  --foreground: #ededed;
+  --background: #282119;
+  --foreground: #ffffff;
 }
 
 .light {

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -11,7 +11,7 @@ import { isAdmin } from "@/lib/auth";
 import Button from "@/components/btn";
 
 export const viewport: Viewport = {
-  themeColor: "#000000",
+  themeColor: "#f4f1ed",
   width: "device-width",
   initialScale: 1,
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,14 +1,11 @@
-import Button from '@/components/btn';
-import { ArrowRightIcon } from '@heroicons/react/24/outline';
-import Link from 'next/link';
 import LangtonLoops from '@/components/Lreplicator';
 import Image from 'next/image';
 import Boids from '@/components/boids';
 import { isAdmin } from '@/lib/auth';
+import HomeClient from './HomeClient';
 
 export default async function Home() {
   const admin = await isAdmin();
-
   return (
     <>
       <div className="hidden sm:block">
@@ -23,83 +20,8 @@ export default async function Home() {
           height={120}
           className="rounded-lg shadow-lg"
         />
-        {!admin && (
-          <Link href="/login">
-            <Button text="login" variant="outline" size="small" />
-          </Link>
-        )}
       </div>
-      <div className="flex flex-col items-center min-h-screen pb-16 md:pb-20">
-        <div className="w-full max-w-3xl mt-16 sm:mt-20 px-4 z-10 text-center sm:text-left">
-          <h1 className="text-4xl sm:text-5xl font-semibold text-gray-400">hello.</h1>
-          <h2 className="mt-2 text-xl sm:text-2xl" style={{ color: 'rgba(180, 90, 70, 0.9)' }}>
-            software engineer @ AWS | RPI CS &apos;23
-          </h2>
-          <p className="mt-4 text-gray-400">
-            self-organizing systems, self-replication, and mechanistic interpretability.
-          </p>
-        </div>
-
-      {/* Buttons row */}
-      <div className="flex flex-col sm:flex-row w-full gap-4 md:gap-6 mt-auto px-4">
-        <Link href="/writings" className="text-white hover:text-gray-300 z-10">
-          <Button
-            text={
-              <>
-                <span className="hidden md:inline">writings</span>
-                <span className="inline md:hidden">writ.</span>
-              </>
-            }
-            variant="outline"
-            size="medium"
-            icon={<ArrowRightIcon className="h-3 w-3" />}
-            iconPosition="right"
-          />
-        </Link>
-        <Link href="/thoughts" className="text-white hover:text-gray-300 z-10">
-          <Button
-            text={
-              <>
-                <span className="hidden md:inline">thoughts</span>
-                <span className="inline md:hidden">thou.</span>
-              </>
-            }
-            variant="outline"
-            size="medium"
-            icon={<ArrowRightIcon className="h-3 w-3" />}
-            iconPosition="right"
-          />
-        </Link>
-        <Link href="/programs" className="text-white hover:text-gray-300 z-10">
-          <Button
-            text={
-              <>
-                <span className="hidden md:inline">programs</span>
-                <span className="inline md:hidden">prog.</span>
-              </>
-            }
-            variant="outline"
-            size="medium"
-            icon={<ArrowRightIcon className="h-3 w-3" />}
-            iconPosition="right"
-          />
-        </Link>
-        <Link href="/playground" className="text-white hover:text-gray-300 z-10">
-          <Button
-            text={
-              <>
-                <span className="hidden md:inline">playground</span>
-                <span className="inline md:hidden">play.</span>
-              </>
-            }
-            variant="outline"
-            size="medium"
-            icon={<ArrowRightIcon className="h-3 w-3" />}
-            iconPosition="right"
-          />
-        </Link>
-      </div>
-    </div>
+      <HomeClient admin={admin} />
     </>
   );
 }

--- a/src/components/Lreplicator.tsx
+++ b/src/components/Lreplicator.tsx
@@ -161,7 +161,7 @@ export default function Lreplicator() {
         initGrid(width, height);
 
         let frameCount = 0;
-        const FRAMES_PER_UPDATE = 10; // Smooth, slow animation
+        const FRAMES_PER_UPDATE = 2; // Faster propagation
 
         const animate = () => {
             frameCount++;

--- a/src/components/theme-provider.tsx
+++ b/src/components/theme-provider.tsx
@@ -12,14 +12,14 @@ interface ThemeContextType {
 const ThemeContext = createContext<ThemeContextType | undefined>(undefined);
 
 export function ThemeProvider({ children }: { children: React.ReactNode }) {
-  const [theme, setTheme] = useState<Theme>('dark');
+  const [theme, setTheme] = useState<Theme>('light');
   const [mounted, setMounted] = useState(false);
 
   useEffect(() => {
     setMounted(true);
-    // Check for saved theme preference or default to 'dark'
+    // Check for saved theme preference or default to 'light'
     const savedTheme = localStorage.getItem('theme') as Theme | null;
-    const initialTheme = savedTheme || 'dark';
+    const initialTheme = savedTheme || 'light';
     setTheme(initialTheme);
     
     // Apply theme class to document

--- a/src/lib/secrets.ts
+++ b/src/lib/secrets.ts
@@ -7,9 +7,13 @@ export async function getAdminPassword(): Promise<string> {
     return cachedPassword;
   }
 
-  const secretName = process.env.ADMIN_PASSWORD_SECRET_NAME;
+  const secretName =
+    process.env.ADMIN_PASSWORD_SECRET_NAME ||
+    process.env.ADMIN_PASSWORD_SECRET_KEY;
   if (!secretName) {
-    throw new Error('ADMIN_PASSWORD_SECRET_NAME env var not set');
+    throw new Error(
+      'ADMIN_PASSWORD_SECRET_NAME or ADMIN_PASSWORD_SECRET_KEY env var not set'
+    );
   }
 
   const client = new SecretsManagerClient({ region: process.env.AWS_REGION });


### PR DESCRIPTION
## Summary
- change dark palette to `#282119` with white text
- accelerate LangtonLoops replicator
- add HomeClient for bottom buttons and reveal-on-scroll nav
- move intro text to a translucent strip below the hero section

## Testing
- `npm install`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688ad22f10a08330ab88879d7e8e24be