### PR TITLE
Update theme colors

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -8,15 +8,15 @@ canvas {
 }
 
 :root {
-  /* Default dark theme */
-  --background: #282119;
-  --foreground: #ffffff;
+  /* Default dark theme - richer reddish brown */
+  --background: #3d221b;
+  --foreground: #f8ede3;
 }
 
 .light {
   /* Anthropic-inspired warm beige theme */
   --background: #f4f1ed;
-  --foreground: #964b3c;
+  --foreground: #5a2d24;
 }
 
 html {


### PR DESCRIPTION
## Summary
- tweak dark theme to use warmer reddish brown background
- make light theme text a darker reddish brown for readability

## Testing
- `npm install`
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688afba93e2c833096e5be8857581120