### PR TITLE
Improve light theme contrast

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -69,20 +69,20 @@ export default function HomeClient({ admin }: { admin: boolean }) {
           <Buttons />
         </div>
       </section>
-      <section className="max-w-3xl mx-auto mt-20 space-y-6 bg-background/60 backdrop-blur-md p-6 text-gray-300">
+      <section className="max-w-3xl mx-auto mt-20 space-y-6 bg-background/60 backdrop-blur-md p-6 text-red-700 dark:text-gray-300">
         <div className="text-center sm:text-left">
-          <h1 className="text-4xl sm:text-5xl font-semibold text-gray-400">hello.</h1>
+          <h1 className="text-4xl sm:text-5xl font-semibold text-red-800 dark:text-gray-400">hello.</h1>
           <h2 className="mt-2 text-xl sm:text-2xl" style={{ color: 'rgba(180, 90, 70, 0.9)' }}>
             software engineer @ AWS | RPI CS &apos;23
           </h2>
-          <p className="mt-4 text-gray-400">
+          <p className="mt-4 text-red-800 dark:text-gray-400">
             self-organizing systems, self-replication, and mechanistic interpretability.
           </p>
         </div>
-        <p>
+        <p className="text-red-800 dark:text-gray-400">
           welcome to my corner of the internet. more content will gradually fill this page as i figure out what belongs here.
         </p>
-        <p>
+        <p className="text-red-800 dark:text-gray-400">
           in the meantime, explore the links above or check back soon for new thoughts and programs.
         </p>
         {!admin && (


### PR DESCRIPTION
## Summary
- ensure home page intro text is readable on light theme

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688aff3dc6fc833096922d6959ba46fa