### PR TITLE
Fix boids and remove static pages

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -4,9 +4,11 @@ import Button from '@/components/btn';
 import { ArrowRightIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
+import { Menu, X } from 'lucide-react';
 
 export default function HomeClient({ admin }: { admin: boolean }) {
   const [showNav, setShowNav] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
 
   useEffect(() => {
     const onScroll = () => {
@@ -16,7 +18,7 @@ export default function HomeClient({ admin }: { admin: boolean }) {
     return () => window.removeEventListener('scroll', onScroll);
   }, []);
 
-  const Buttons = () => (
+  const Buttons = ({ onClick }: { onClick?: () => void } = {}) => (
     <>
       <Link href="/writings">
         <Button
@@ -25,6 +27,7 @@ export default function HomeClient({ admin }: { admin: boolean }) {
           size="medium"
           icon={<ArrowRightIcon className="h-3 w-3" />}
           iconPosition="right"
+          onClick={onClick}
         />
       </Link>
       <Link href="/thoughts">
@@ -34,6 +37,7 @@ export default function HomeClient({ admin }: { admin: boolean }) {
           size="medium"
           icon={<ArrowRightIcon className="h-3 w-3" />}
           iconPosition="right"
+          onClick={onClick}
         />
       </Link>
       <Link href="/programs">
@@ -43,6 +47,7 @@ export default function HomeClient({ admin }: { admin: boolean }) {
           size="medium"
           icon={<ArrowRightIcon className="h-3 w-3" />}
           iconPosition="right"
+          onClick={onClick}
         />
       </Link>
       <Link href="/playground">
@@ -52,6 +57,7 @@ export default function HomeClient({ admin }: { admin: boolean }) {
           size="medium"
           icon={<ArrowRightIcon className="h-3 w-3" />}
           iconPosition="right"
+          onClick={onClick}
         />
       </Link>
     </>
@@ -60,12 +66,24 @@ export default function HomeClient({ admin }: { admin: boolean }) {
   return (
     <>
       <nav
-        className={`fixed top-0 w-full bg-background/80 backdrop-blur-sm flex justify-center gap-4 py-2 z-40 transition-opacity ${showNav ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
+        className={`fixed top-0 w-full bg-background/80 backdrop-blur-sm flex justify-center sm:justify-center gap-4 py-2 z-40 transition-opacity ${showNav ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
       >
-        <Buttons />
+        <div className="hidden sm:flex gap-4">
+          <Buttons />
+        </div>
+        <div className="flex sm:hidden justify-between w-full px-4">
+          <button onClick={() => setMenuOpen(!menuOpen)} aria-label="Menu">
+            {menuOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+          </button>
+        </div>
       </nav>
+      {menuOpen && (
+        <div className="sm:hidden fixed top-10 left-0 right-0 bg-background/95 backdrop-blur-md flex flex-col items-center gap-2 py-4 z-40">
+          <Buttons onClick={() => setMenuOpen(false)} />
+        </div>
+      )}
       <section className="flex flex-col items-center justify-end min-h-screen pb-16 md:pb-20">
-        <div className={`flex justify-center gap-4 transition-opacity ${showNav ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}> 
+        <div className={`hidden sm:flex justify-center gap-4 transition-opacity ${showNav ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}>
           <Buttons />
         </div>
       </section>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,8 +8,8 @@ export default async function Home() {
   const admin = await isAdmin();
   return (
     <>
+      <Boids />
       <div className="hidden sm:block">
-        <Boids />
         <LangtonLoops />
       </div>
       <div className="sm:fixed sm:top-4 sm:right-4 z-50 flex flex-col items-center gap-2 mt-4 sm:mt-0">

--- a/src/app/playground/[slug]/page.tsx
+++ b/src/app/playground/[slug]/page.tsx
@@ -1,26 +1,18 @@
 import { notFound } from 'next/navigation';
 import PlaygroundContainer from '@/components/playground-container';
-import { getPlaygroundProgram, getAllPlaygroundPrograms } from '@/lib/playground-registry';
+import { getPlaygroundProgram } from '@/lib/playground-registry';
 
-export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 interface PlaygroundPageProps {
-  params: Promise<{
+  params: {
     slug: string
-  }>
+  }
 }
 
-export async function generateStaticParams() {
-  const programs = getAllPlaygroundPrograms();
-  
-  return programs.map((program) => ({
-    slug: program.id,
-  }))
-}
 
-export default async function PlaygroundPage({ params }: PlaygroundPageProps) { 
-  const awaitedParams = await params;
-  const program = getPlaygroundProgram(awaitedParams.slug);
+export default async function PlaygroundPage({ params }: PlaygroundPageProps) {
+  const program = getPlaygroundProgram(params.slug);
 
   if (!program) {
     notFound();

--- a/src/app/programs/[slug]/page.tsx
+++ b/src/app/programs/[slug]/page.tsx
@@ -2,18 +2,18 @@ import { notFound } from 'next/navigation';
 import NavigationButton from '@/components/navigation-button';
 import Program from '@/components/program';
 import { getProgram } from '@/lib/data/programs';
+import Boids from '@/components/boids';
 
 export const dynamic = 'force-dynamic';
 
 interface ProgramPageProps {
-  params: Promise<{
+  params: {
     slug: string
-  }>
+  }
 }
 
 export default async function ProgramPage({ params }: ProgramPageProps) {
-  const awaitedParams = await params;
-  const programData = await getProgram(awaitedParams.slug);
+  const programData = await getProgram(params.slug);
 
     
   if (!programData) {
@@ -21,7 +21,8 @@ export default async function ProgramPage({ params }: ProgramPageProps) {
   }
 
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col relative">
+      <Boids />
       <Program content={programData.content} videoName={programData.videoName} githubUrl={programData.githubUrl} />
       <NavigationButton />
     </div>

--- a/src/app/thoughts/[slug]/page.tsx
+++ b/src/app/thoughts/[slug]/page.tsx
@@ -2,26 +2,27 @@ import { notFound } from 'next/navigation';
 import Thought from '@/components/thought';
 import { getThought } from '@/lib/data/thoughts';
 import NavigationButton from '@/components/navigation-button';
+import Boids from '@/components/boids';
 
 export const dynamic = 'force-dynamic';
 
 interface ThoughtPageProps {
-  params: Promise<{
+  params: {
     slug: string
-  }>
+  }
 }
 
 
 export default async function ThoughtPage({ params }: ThoughtPageProps) {
-  const awaitedParams = await params;
-  const thoughtData = await getThought(awaitedParams.slug);
+  const thoughtData = await getThought(params.slug);
   
   if (!thoughtData) {
     notFound();
   }
 
   return (
-    <div>
+    <div className="min-h-screen relative">
+      <Boids />
       <Thought content={thoughtData.content} date={thoughtData.date} />
       <NavigationButton />
     </div>

--- a/src/app/writings/[slug]/page.tsx
+++ b/src/app/writings/[slug]/page.tsx
@@ -2,25 +2,26 @@ import { notFound } from 'next/navigation';
 import Writing from '@/components/writing';
 import NavigationButton from '@/components/navigation-button';
 import { getWriting } from '@/lib/data/writings';
+import Boids from '@/components/boids';
 
 export const dynamic = 'force-dynamic';
 
 interface WritingPageProps {
-  params: Promise<{
+  params: {
     slug: string
-  }>
+  }
 }
 
 export default async function WritingPage({ params }: WritingPageProps) {
-  const awaitedParams = await params;
-  const writingData = await getWriting(awaitedParams.slug);
+  const writingData = await getWriting(params.slug);
   
   if (!writingData) {
     notFound();
   }
 
   return (
-    <div>
+    <div className="min-h-screen relative">
+      <Boids />
       <Writing title={writingData.title} content={writingData.content} date={writingData.date} />
       <NavigationButton />
     </div>


### PR DESCRIPTION
## Summary
- remove static regeneration for playground routes
- add boid background across dynamic content
- improve mobile UX with dropdown menu
- display boids on all screen sizes

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_688b0497460883309ee641034c500967