### PR TITLE
Add blinking scroll hint

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Button from '@/components/btn';
-import { ArrowRightIcon } from '@heroicons/react/24/outline';
+import { ArrowRightIcon, ArrowUpIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
 import { useEffect, useState } from 'react';
 import { Menu, X } from 'lucide-react';
@@ -83,7 +83,10 @@ export default function HomeClient({ admin }: { admin: boolean }) {
         </div>
       )}
       <section className="flex flex-col items-center justify-end min-h-screen pb-16 md:pb-20">
-        <div className={`hidden sm:flex justify-center gap-4 transition-opacity ${showNav ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}>
+        <div
+          className={`hidden sm:flex flex-col items-center gap-2 transition-opacity ${showNav ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
+        >
+          {!showNav && <ArrowUpIcon className="w-6 h-6 blink" />}
           <Buttons />
         </div>
       </section>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -25,16 +25,29 @@ html {
   overflow-x: hidden;
 }
 
-body {
-  color: var(--foreground);
-  background: var(--background);
-  transition: background-color 0.3s ease, color 0.3s ease;
-  min-height: 100%;
-  overflow-x: hidden;
+  body {
+    color: var(--foreground);
+    background: var(--background);
+    transition: background-color 0.3s ease, color 0.3s ease;
+    min-height: 100%;
+    overflow-x: hidden;
+  }
+
+  @media (max-width: 640px) {
+    body {
+      padding: 1rem;
+    }
+  }
+
+@keyframes blink {
+  0%, 100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0;
+  }
 }
 
-@media (max-width: 640px) {
-  body {
-    padding: 1rem;
-  }
+.blink {
+  animation: blink 1s step-start infinite;
 }


### PR DESCRIPTION
## Summary
- show an upward blinking arrow over the bottom nav buttons on the home page
- hide the arrow when the top navigation bar is visible

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b789f11cc83308f8b148ff6f9e5d4