### PR TITLE
Improve admin authentication security

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,4 +18,7 @@ Set `AWS_REGION` and either `ADMIN_PASSWORD_SECRET_NAME` or
 containing your admin credentials. The secret JSON must include an
 `ADMIN_PASSWORD` field.
 
+`ADMIN_TOKEN_SECRET` must also be set to a random string used to sign the
+admin session cookie.
+
 

--- a/src/app/api/admin/programs/route.ts
+++ b/src/app/api/admin/programs/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
+import { isAdmin } from '@/lib/auth';
 import { PutCommand } from '@aws-sdk/lib-dynamodb';
 import { getDocClient } from '@/lib/dynamodb';
 
 export async function POST(req: Request) {
-  const cookieStore = await cookies();
-  if (cookieStore.get('adminAuth')?.value !== 'true') {
+  if (!(await isAdmin())) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
   const data = await req.json();

--- a/src/app/api/admin/thoughts/route.ts
+++ b/src/app/api/admin/thoughts/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
+import { isAdmin } from '@/lib/auth';
 import { PutCommand } from '@aws-sdk/lib-dynamodb';
 import { getDocClient } from '@/lib/dynamodb';
 
 export async function POST(req: Request) {
-  const cookieStore = await cookies();
-  if (cookieStore.get('adminAuth')?.value !== 'true') {
+  if (!(await isAdmin())) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
   const data = await req.json();

--- a/src/app/api/admin/writings/route.ts
+++ b/src/app/api/admin/writings/route.ts
@@ -1,11 +1,10 @@
 import { NextResponse } from 'next/server';
-import { cookies } from 'next/headers';
+import { isAdmin } from '@/lib/auth';
 import { PutCommand } from '@aws-sdk/lib-dynamodb';
 import { getDocClient } from '@/lib/dynamodb';
 
 export async function POST(req: Request) {
-  const cookieStore = await cookies();
-  if (cookieStore.get('adminAuth')?.value !== 'true') {
+  if (!(await isAdmin())) {
     return NextResponse.json({ error: 'unauthorized' }, { status: 401 });
   }
   const data = await req.json();

--- a/src/app/api/login/route.ts
+++ b/src/app/api/login/route.ts
@@ -1,12 +1,18 @@
 import { NextResponse } from 'next/server';
 import { getAdminPassword } from '@/lib/secrets';
+import { createAdminToken } from '@/lib/auth';
 
 export async function POST(req: Request) {
   const { password } = await req.json();
   const adminPassword = await getAdminPassword();
   if (password === adminPassword) {
     const res = NextResponse.json({ success: true });
-    res.cookies.set('adminAuth', 'true', { httpOnly: true, path: '/' });
+    const token = createAdminToken();
+    res.cookies.set('adminAuth', token, {
+      httpOnly: true,
+      path: '/',
+      sameSite: 'lax'
+    });
     return res;
   }
   return NextResponse.json({ success: false }, { status: 401 });

--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -1,7 +1,50 @@
 import { cookies } from 'next/headers';
+import crypto from 'crypto';
+
+function getSecret() {
+  const secret = process.env.ADMIN_TOKEN_SECRET;
+  if (!secret) {
+    throw new Error('ADMIN_TOKEN_SECRET not set');
+  }
+  return secret;
+}
+
+function sign(payload: string) {
+  const h = crypto.createHmac('sha256', getSecret());
+  h.update(payload);
+  const signature = h.digest('hex');
+  return `${payload}.${signature}`;
+}
+
+function verify(token: string): string | null {
+  const idx = token.lastIndexOf('.');
+  if (idx === -1) return null;
+  const payload = token.slice(0, idx);
+  const signature = token.slice(idx + 1);
+  const h = crypto.createHmac('sha256', getSecret());
+  h.update(payload);
+  const expected = h.digest('hex');
+  const sigBuf = Buffer.from(signature);
+  const expBuf = Buffer.from(expected);
+  if (sigBuf.length !== expBuf.length) return null;
+  const valid = crypto.timingSafeEqual(sigBuf, expBuf);
+  return valid ? payload : null;
+}
+
+export function createAdminToken() {
+  const exp = Math.floor(Date.now() / 1000) + 60 * 60 * 24; // 24h
+  return sign(`admin:${exp}`);
+}
 
 export async function isAdmin() {
   const cookieStore = await cookies();
-  const value = cookieStore.get('adminAuth')?.value;
-  return value === 'true';
+  const token = cookieStore.get('adminAuth')?.value;
+  if (!token) return false;
+  const payload = verify(token);
+  if (!payload) return false;
+  const [role, exp] = payload.split(':');
+  if (role !== 'admin') return false;
+  const expiry = parseInt(exp, 10);
+  if (!expiry || Date.now() / 1000 > expiry) return false;
+  return true;
 }


### PR DESCRIPTION
## Summary
- use signed cookies for admin sessions
- update login API to issue a signed token
- guard admin APIs with new `isAdmin()` helper
- document `ADMIN_TOKEN_SECRET` environment variable

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_688b7cd1d974833093f759d9ec55347a