### PR TITLE
feat: add theme-aware custom cursor

### DIFF
--- a/public/cursor-dark.svg
+++ b/public/cursor-dark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+  <circle cx="12" cy="12" r="8" stroke="#f8ede3" stroke-width="2" fill="none"/>
+  <circle cx="12" cy="12" r="3" fill="#f8ede3"/>
+</svg>

--- a/public/cursor-light.svg
+++ b/public/cursor-light.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24">
+  <circle cx="12" cy="12" r="8" stroke="#5a2d24" stroke-width="2" fill="none"/>
+  <circle cx="12" cy="12" r="3" fill="#5a2d24"/>
+</svg>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -28,10 +28,25 @@ html {
   body {
     color: var(--foreground);
     background: var(--background);
+    cursor: url('/cursor-dark.svg') 12 12, default;
     transition: background-color 0.3s ease, color 0.3s ease;
     min-height: 100%;
     overflow-x: hidden;
   }
+
+.light body {
+  cursor: url('/cursor-light.svg') 12 12, default;
+}
+
+a,
+button {
+  cursor: url('/cursor-dark.svg') 12 12, pointer;
+}
+
+html.light a,
+html.light button {
+  cursor: url('/cursor-light.svg') 12 12, pointer;
+}
 
   @media (max-width: 640px) {
     body {


### PR DESCRIPTION
## Summary
- add light and dark custom cursor svg assets
- apply theme-aware cursor globally via globals.css

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688d6c6016988330a448764cc0eb575c