### PR TITLE
Place admin add buttons top-left with plus icon

### DIFF
--- a/src/app/programs/page.tsx
+++ b/src/app/programs/page.tsx
@@ -2,6 +2,7 @@ import Link from 'next/link';
 import NavigationButton from '@/components/navigation-button';
 import { getAllPrograms } from '@/lib/data/programs';
 import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
+import PlusIcon from '@heroicons/react/24/outline/PlusIcon';
 import Button from '@/components/btn';
 import Boids from '@/components/boids';
 import { isAdmin } from '@/lib/auth';
@@ -26,11 +27,16 @@ export default async function ProgramsPage() {
         ))}
       </div>
       {admin && (
-        <div className="mt-4">
-          <Link href="/programs/new">
-            <Button text="add program" variant="outline" />
-          </Link>
-        </div>
+        <Link
+          href="/programs/new"
+          className="absolute top-4 left-4 z-10"
+        >
+          <Button
+            text="add program"
+            variant="ghost"
+            icon={<PlusIcon className="h-4 w-4" />}
+          />
+        </Link>
       )}
       <NavigationButton />
     </div>

--- a/src/app/thoughts/page.tsx
+++ b/src/app/thoughts/page.tsx
@@ -3,6 +3,7 @@ import NavigationButton from '@/components/navigation-button';
 import { getAllThoughts } from '@/lib/data/thoughts';
 import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
 import Button from '@/components/btn';
+import PlusIcon from '@heroicons/react/24/outline/PlusIcon';
 import Boids from '@/components/boids';
 import { isAdmin } from '@/lib/auth';
 
@@ -67,11 +68,16 @@ export default async function ThoughtsPage() {
         )}
       </div>
       {admin && (
-        <div className="mt-4">
-          <Link href="/thoughts/new">
-            <Button text="add thought" variant="outline" />
-          </Link>
-        </div>
+        <Link
+          href="/thoughts/new"
+          className="absolute top-4 left-4 z-10"
+        >
+          <Button
+            text="add thought"
+            variant="ghost"
+            icon={<PlusIcon className="h-4 w-4" />}
+          />
+        </Link>
       )}
       <NavigationButton />
     </div>

--- a/src/app/writings/page.tsx
+++ b/src/app/writings/page.tsx
@@ -3,6 +3,7 @@ import NavigationButton from '@/components/navigation-button';
 import { getAllWritings } from '@/lib/data/writings';
 import Button from '@/components/btn';
 import ArrowRightIcon from '@heroicons/react/24/outline/ArrowRightIcon';
+import PlusIcon from '@heroicons/react/24/outline/PlusIcon';
 import Boids from '@/components/boids';
 import { isAdmin } from '@/lib/auth';
 
@@ -72,11 +73,16 @@ export default async function WritingsPage() {
         )}
       </div>
       {admin && (
-        <div className="mt-4">
-          <Link href="/writings/new">
-            <Button text="add writing" variant="outline" />
-          </Link>
-        </div>
+        <Link
+          href="/writings/new"
+          className="absolute top-4 left-4 z-10"
+        >
+          <Button
+            text="add writing"
+            variant="ghost"
+            icon={<PlusIcon className="h-4 w-4" />}
+          />
+        </Link>
       )}
       <NavigationButton />
     </div>


### PR DESCRIPTION
## Summary
- Move admin-only add buttons to the top-left on programs, writings and thoughts pages
- Style add buttons with a plus icon and ghost variant for a transparent background

## Testing
- `pnpm lint`

------
https://chatgpt.com/codex/tasks/task_e_688d760b791083308712bbd88dfeeb76