### PR TITLE
Improve navigation and theme styling

### DIFF
--- a/src/app/HomeClient.tsx
+++ b/src/app/HomeClient.tsx
@@ -1,22 +1,13 @@
 'use client';
 
 import Button from '@/components/btn';
-import { ArrowRightIcon, ArrowUpIcon } from '@heroicons/react/24/outline';
+import { ArrowRightIcon } from '@heroicons/react/24/outline';
 import Link from 'next/link';
-import { useEffect, useState } from 'react';
+import { useState } from 'react';
 import { Menu, X } from 'lucide-react';
 
 export default function HomeClient({ admin }: { admin: boolean }) {
-  const [showNav, setShowNav] = useState(false);
   const [menuOpen, setMenuOpen] = useState(false);
-
-  useEffect(() => {
-    const onScroll = () => {
-      setShowNav(window.scrollY > window.innerHeight * 0.1);
-    };
-    window.addEventListener('scroll', onScroll);
-    return () => window.removeEventListener('scroll', onScroll);
-  }, []);
 
   const Buttons = ({ onClick }: { onClick?: () => void } = {}) => (
     <>
@@ -65,9 +56,7 @@ export default function HomeClient({ admin }: { admin: boolean }) {
 
   return (
     <>
-      <nav
-        className={`fixed top-0 w-full bg-background/80 backdrop-blur-sm flex justify-center sm:justify-center gap-4 py-2 z-40 transition-opacity ${showNav ? 'opacity-100' : 'opacity-0 pointer-events-none'}`}
-      >
+      <nav className="fixed top-0 w-full bg-background/80 backdrop-blur-sm flex justify-center sm:justify-center gap-4 py-2 z-40">
         <div className="hidden sm:flex gap-4">
           <Buttons />
         </div>
@@ -82,15 +71,7 @@ export default function HomeClient({ admin }: { admin: boolean }) {
           <Buttons onClick={() => setMenuOpen(false)} />
         </div>
       )}
-      <section className="flex flex-col items-center justify-end min-h-screen pb-16 md:pb-20">
-        <div
-          className={`hidden sm:flex flex-col items-center gap-2 transition-opacity ${showNav ? 'opacity-0 pointer-events-none' : 'opacity-100'}`}
-        >
-          {!showNav && <ArrowUpIcon className="w-6 h-6 blink" />}
-          <Buttons />
-        </div>
-      </section>
-      <section className="max-w-3xl mx-auto mt-20 space-y-6 bg-background/60 backdrop-blur-md p-6 text-red-700 dark:text-gray-300">
+      <section className="max-w-3xl mx-auto mt-24 space-y-6 bg-background/60 backdrop-blur-md p-6 text-red-700 dark:text-gray-300">
         <div className="text-center sm:text-left">
           <h1 className="text-4xl sm:text-5xl font-semibold text-red-800 dark:text-gray-400">hello.</h1>
           <h2 className="mt-2 text-xl sm:text-2xl" style={{ color: 'rgba(180, 90, 70, 0.9)' }}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -12,7 +12,7 @@ export default async function Home() {
       <div className="hidden sm:block">
         <LangtonLoops />
       </div>
-      <div className="sm:fixed sm:top-4 sm:right-4 z-50 flex flex-col items-center gap-2 mt-4 sm:mt-0">
+      <div className="fixed top-4 right-4 z-50 flex flex-col items-center gap-2">
         <Image
           src="/images/pixelated-sami.png"
           alt="Sami"

--- a/src/components/boids.tsx
+++ b/src/components/boids.tsx
@@ -187,9 +187,9 @@ export default function Boids() {
         lastHeight = newHeight;
 
         let updated = false;
-        const wordD = { small: 8, medium: 5, large: 4 };
-        const imgD = { small: 8, medium: 5, large: 4 };
-        const MAX_POINTS = { small: 1000, medium: 2000, large: 3000 };
+        const wordD = { small: 5, medium: 3, large: 2 };
+        const imgD = { small: 6, medium: 4, large: 3 };
+        const MAX_POINTS = { small: 2000, medium: 4000, large: 6000 };
         // pick image src by matching route prefix
         const keys = Object.keys(imageMap);
         const matchKey = keys.find(key => route.startsWith(key));

--- a/src/components/goback.tsx
+++ b/src/components/goback.tsx
@@ -4,6 +4,7 @@ import { useEffect, useState } from "react";
 
 import "./components.css";
 import Button from "./btn";
+import { ArrowLeft } from "lucide-react";
 
 export default function GoBack() {
   const router = useRouter();
@@ -35,8 +36,10 @@ export default function GoBack() {
     <div className="fixed bottom-4 left-4 z-50">
       <Button
         onClick={() => router.back()}
-        className="text-white hover:text-gray-300"
         text="go back"
+        variant="outline"
+        size="small"
+        icon={<ArrowLeft className="h-3 w-3" />}
       />
     </div>
   );

--- a/src/components/home-button.tsx
+++ b/src/components/home-button.tsx
@@ -8,13 +8,13 @@ export default function HomeButton() {
   const router = useRouter();
 
   return (
-    <div className="fixed bottom-4 left-20 z-50">
+    <div className="fixed bottom-4 left-4 z-50">
       <button
         onClick={() => router.push('/')}
-        className="p-2 bg-gray-800 text-white hover:bg-gray-700 rounded-lg transition-colors duration-200 flex items-center gap-2"
+        className="p-2 border border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)] rounded-md transition-colors duration-200 hover:bg-[var(--foreground)] hover:text-[var(--background)]"
         aria-label="Go to home"
       >
-        <Home className="w-5 h-5" />
+        <Home className="w-4 h-4" />
       </button>
     </div>
   );

--- a/src/components/theme-toggle.tsx
+++ b/src/components/theme-toggle.tsx
@@ -10,13 +10,13 @@ function ThemeToggleButton() {
   return (
     <button
       onClick={toggleTheme}
-      className="fixed bottom-2 right-20 z-50 p-2 rounded-lg bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-200 hover:bg-gray-300 dark:hover:bg-gray-700 transition-all duration-200"
+      className="fixed bottom-4 right-4 z-50 p-2 border border-[var(--foreground)] bg-[var(--background)] text-[var(--foreground)] rounded-md transition-colors duration-200 hover:bg-[var(--foreground)] hover:text-[var(--background)]"
       aria-label="Toggle theme"
     >
       {theme === 'dark' ? (
-        <SunIcon className="h-5 w-5" />
+        <SunIcon className="h-4 w-4" />
       ) : (
-        <MoonIcon className="h-5 w-5" />
+        <MoonIcon className="h-4 w-4" />
       )}
     </button>
   );


### PR DESCRIPTION
## Summary
- Always show navigation and clean mobile layout
- Restyle utility buttons to match theme
- Increase boid density for clearer home text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688e50a71c248330bef775de687a47f1